### PR TITLE
Add license details to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ location.map_reference == 'ST 58801 71043'
 ### From OS Map Reference to Longitude and Latitude
 
 If your end result needs to be longitude and latitude, you can combine the
-OsMapRef output with that of another gem: 
+OsMapRef output with that of another gem:
 [global_convert](https://github.com/reggieb/global_convert)
 
 For example
@@ -72,13 +72,28 @@ puts "Longitude = #{location.lon} in radians."
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. 
-Then, run `rake test` to run the tests. You can also run `bin/console` 
+After checking out the repo, run `bin/setup` to install dependencies.
+Then, run `rake test` to run the tests. You can also run `bin/console`
 for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. 
+To install this gem onto your local machine, run `bundle exec rake install`.
 
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/reggieb/os_map_ref.
 
+## License
+
+THIS INFORMATION IS LICENSED UNDER THE CONDITIONS OF THE OPEN GOVERNMENT LICENCE found at:
+
+http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3
+
+The following attribution statement MUST be cited in your products and applications when using this information.
+
+> Contains public sector information licensed under the Open Government license v3
+
+### About the license
+
+The Open Government Licence (OGL) was developed by the Controller of Her Majesty's Stationery Office (HMSO) to enable information providers in the public sector to license the use and re-use of their information under a common open licence.
+
+It is designed to encourage use and re-use of information freely and flexibly, with only a few conditions.

--- a/Rakefile
+++ b/Rakefile
@@ -7,4 +7,6 @@ Rake::TestTask.new(:test) do |t|
   t.test_files = FileList['test/**/*_test.rb']
 end
 
-task :default => :spec
+task :spec => :test
+
+task :default => :test


### PR DESCRIPTION
This adds an overview and explanation of the license used by this repo (OGL) to the README as per the standard convention for Environment Agency public repositories.
