### PR TITLE
fixed typo in prefix matrix

### DIFF
--- a/lib/os_map_ref/location.rb
+++ b/lib/os_map_ref/location.rb
@@ -1,92 +1,92 @@
 require 'matrix'
 module OsMapRef
   class Location
-    
+
     def self.for(text)
       input_processor = InputProcessor.new(text)
       new input_processor.params
     end
-    
+
     def initialize(args={})
       @map_reference = args[:map_reference].freeze if args[:map_reference]
       @easting = args[:easting].to_i if args[:easting]
       @northing = args[:northing].to_i if args[:northing]
     end
-    
+
     def map_reference
       @map_reference ||= build_map_reference.freeze
     end
-    
+
     def build_map_reference
       [grid_reference_prefix, short_easting, short_northing].join(' ')
     end
-    
+
     def grid_easting
       easting.to_s[0].to_i
     end
-    
+
     def short_easting
       easting.to_s[1..-1].to_i
     end
-    
+
     def long_northing?
       northing.to_s.length >= 7
     end
-    
+
     def grid_northing
       northing.to_s[0..(chars_in_northing_start - 1)].to_i
     end
-    
+
     def short_northing
       northing.to_s[chars_in_northing_start..-1].to_i
     end
-    
+
     def chars_in_northing_start
       long_northing? ? 2 : 1
     end
-    
+
     def grid_reference_prefix
       grid[grid_northing][grid_easting]
     end
-    
+
     def easting
       @easting ||= easting_from_map_reference.to_i
     end
-    
+
     def northing
       @northing ||= northing_from_map_reference.to_i
-    end    
-    
+    end
+
     def northing_from_map_reference
       northing_easting_from_map_reference[0].to_s + map_reference_parts[2]
     end
-    
+
     def easting_from_map_reference
       northing_easting_from_map_reference[1].to_s + map_reference_parts[1]
     end
-    
+
     # The parts should be a pair of letters then two sets of numbers
-    # 'ST 58901 71053' becomes ['ST', '58901', '71053']   
+    # 'ST 58901 71053' becomes ['ST', '58901', '71053']
     def map_reference_parts
       @map_reference_parts ||= map_reference.split
     end
-    
+
     # Returns array of [grid_northing, grid_easting] for the gird element
     # matching the map reference start. So 'ST 58901 71053' will return [1, 3]
     def northing_easting_from_map_reference
       @northing_easting_from_map_reference ||= matrix.index map_reference_parts[0]
     end
-    
+
     def matrix
       @matrix ||= Matrix[*grid]
     end
-    
+
     # Grid of 100km squares as they are arranged over the UK.
-    # The grid is reversed so that the origin (0,0) is the 
+    # The grid is reversed so that the origin (0,0) is the
     # bottom left corner ('SV').
     def grid
       @grid ||= [
-        %w[HL HM HN HO HP JL JM JH JO JP],
+        %w[HL HM HN HO HP JL JM JN JO JP],
         %w[HQ HR HS HT HU JQ JR JS JT JU],
         %w[HV HW HX HY HZ JV JW JX JY JZ],
         %w[NA NB NC ND NE OA OB OC OD OE],


### PR DESCRIPTION
Just spotted a typo in the matrix whilst I was looking at it,
