### PR TITLE
Update travis configuration for repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,16 @@
 language: ruby
+cache: bundler
+
 rvm:
   - 2.2.3
+
 before_install: gem install bundler -v 1.11.2
+
+# Have this option to stop travis-ci building twice. Currently we have travis set to build both
+# PR's and pushes. However this means when we push to a PR we have to wait for Travis to finish
+# 2 builds. If we unticked 'pushes' when the PR was finally merged that would not be built. The
+# brute force approach would be to untick build PR's and just build all pushes. We instead have
+# gone with the approach outlined here http://stackoverflow.com/a/31882307
+branches:
+  only:
+    - master

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OsMapRef
 
+[![Build Status](https://travis-ci.org/EnvironmentAgency/os_map_ref.svg?branch=master)](https://travis-ci.org/EnvironmentAgency/os_map_ref)
+
 This gem allows you to gather U.K. Ordnance Survey Eastings, North, and Map
 References from a range of text inputs.
 


### PR DESCRIPTION
This change makes the following changes to our Travis-CI configuration
- Stops travis building twice for a particular commit
- Cache's dependencies between build
- Adds the travis build badge to the README
