### PR TITLE
Fix/improve range of inputs accepted

### DIFF
--- a/lib/os_map_ref/input_processor.rb
+++ b/lib/os_map_ref/input_processor.rb
@@ -58,12 +58,12 @@ module OsMapRef
     end
 
     def padded_map_reference_easting
-      map_reference_easting.ljust(5, '0')
+      map_reference_easting.ljust((normal_length - 1), padding)
     end
 
     def padded_map_reference_northing
-      target_length = northing_longer_than_easting? ? 6 : 5
-      map_reference_northing.ljust(target_length, '0')
+      target_length = northing_longer_than_easting? ? extended_length : normal_length
+      map_reference_northing.ljust((target_length - 1), padding)
     end
 
     def northing_longer_than_easting?
@@ -80,11 +80,41 @@ module OsMapRef
 
     def get_easting_and_northing
       match = easting_northing_pattern.match input
-      (1..2).collect{|n| match[n].ljust(6, '0').to_i}
+      easting = match[1]
+      northing = match[3]
+      length = northing.length > easting.length ? extended_length : normal_length
+      [
+        easting.ljust(normal_length, padding),
+        northing.ljust(length, padding)
+      ]
     end
-
+    
+    def extended_length
+      normal_length + 1
+    end
+    
+    def normal_length
+      6
+    end
+    
+    def padding
+      '0'
+    end
+        
+    # Matches are:
+    # 1: First digits which may be followed with a decimal point and more digits
+    # 2: The decimal point and trailing digits from first match (if present)
+    # 3: Second digits which may be followed with a decimal point and more digits
+    # 4: The decimal point and trailing digits from second match (if present)
+    # So: 
+    # "1234.5, 6789.0" --> 1: "1234.5", 2: ".5", 3: "6789.0", 4: ".0"
+    # "1234 6789"      --> 1: "1234",   2: nil,  3: "6789",   4: nil
     def easting_northing_pattern
-      /(\d{3,6})[\,\s]+(\d{3,6})/
+      eastings = /\d{3,6}/    # 3 to 6 digits
+      northings = /\d{3,7}/    # 3 to 7 digits
+      decimals = /\.\d+/    # decimal point and trailing digits
+      separator = /[\,\s]+/ # commas or spaces
+      /(#{eastings}(#{decimals})?)#{separator}(#{northings}(#{decimals})?)/
     end
   end
 end

--- a/lib/os_map_ref/location.rb
+++ b/lib/os_map_ref/location.rb
@@ -26,7 +26,7 @@ module OsMapRef
     end
 
     def short_easting
-      easting.to_s[1..-1].to_i
+      easting.to_s[1..-1]
     end
 
     def long_northing?
@@ -38,7 +38,7 @@ module OsMapRef
     end
 
     def short_northing
-      northing.to_s[chars_in_northing_start..-1].to_i
+      northing.to_s[chars_in_northing_start..-1]
     end
 
     def chars_in_northing_start

--- a/lib/os_map_ref/location.rb
+++ b/lib/os_map_ref/location.rb
@@ -9,8 +9,12 @@ module OsMapRef
 
     def initialize(args={})
       @map_reference = args[:map_reference].freeze if args[:map_reference]
-      @easting = args[:easting].to_i if args[:easting]
-      @northing = args[:northing].to_i if args[:northing]
+      @easting = remove_decimals(args[:easting]) if args[:easting]
+      @northing = remove_decimals(args[:northing]) if args[:northing]
+    end
+    
+    def remove_decimals(number)
+      number.to_s.sub /\.\d*/, ""
     end
 
     def map_reference
@@ -50,11 +54,11 @@ module OsMapRef
     end
 
     def easting
-      @easting ||= easting_from_map_reference.to_i
+      @easting ||= easting_from_map_reference
     end
 
     def northing
-      @northing ||= northing_from_map_reference.to_i
+      @northing ||= northing_from_map_reference
     end
 
     def northing_from_map_reference

--- a/lib/os_map_ref/version.rb
+++ b/lib/os_map_ref/version.rb
@@ -1,3 +1,3 @@
 module OsMapRef
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/spec/os_map_ref/input_processor_spec.rb
+++ b/spec/os_map_ref/input_processor_spec.rb
@@ -2,10 +2,10 @@ require "spec_helper"
 
 describe OsMapRef::InputProcessor do
 
-  let(:map_reference) { 'ST 58901 71053' }
-  let(:long_map_reference) { 'ST 58901 121053' }
-  let(:easting) { 358901 }
-  let(:northing) { 171053 }
+  let(:map_reference) { "ST 58901 71053" }
+  let(:long_map_reference) { "HT 58901 71053" }
+  let(:easting) { "358901" }
+  let(:northing) { "171053" }
 
   describe ".new" do
     context 'with map reference' do
@@ -68,9 +68,27 @@ describe OsMapRef::InputProcessor do
     
     context 'with short eastings and northings' do
       it 'should pad out short input' do
-        input = ['123', '456'].join(' ')
+        input = "123 456"
         input_cleaner = described_class.new(input)
-        expected = {easting: 123000, northing: 456000}
+        expected = {easting: "123000", northing: "456000"}
+        expect(input_cleaner.params).to eq(expected)
+      end
+    end
+    
+    context 'with short eastings and northings, but longer northing' do
+      it 'should pad out short input' do
+        input = "456 1234"
+        input_cleaner = described_class.new(input)
+        expected = {easting: "456000", northing: "1234000"}
+        expect(input_cleaner.params).to eq(expected)
+      end
+    end
+    
+    context "with decimals in eastings and northings" do
+      it "should pass on the decimal elements" do
+        input = "308901.4,101053.3"
+        input_cleaner = described_class.new(input)
+        expected = {easting: "308901.4", northing: "101053.3"}
         expect(input_cleaner.params).to eq(expected)
       end
     end

--- a/spec/os_map_ref/location_spec.rb
+++ b/spec/os_map_ref/location_spec.rb
@@ -84,7 +84,7 @@ describe OsMapRef::Location do
     
     describe ".short_easting" do
       it "should be number after first number of easting" do
-        expect(location.short_easting).to eq(58901)
+        expect(location.short_easting).to eq("58901")
       end
     end
     
@@ -96,7 +96,7 @@ describe OsMapRef::Location do
     
     describe ".short_northing" do
       it "should be number after first number of northing" do
-        expect(location.short_northing).to eq(71053)
+        expect(location.short_northing).to eq("71053")
       end
     end
   end
@@ -112,9 +112,22 @@ describe OsMapRef::Location do
     
     describe ".short_northing" do
       it "should be the number after the first two numbers of northing" do
-        expect(location.short_northing).to eq(71053)
+        expect(location.short_northing).to eq("71053")
       end
     end
-  end  
+  end
+  
+  context "when eastings and northing second character a zero" do
+    let(:map_reference) { 'ST 08901 01053' }
+    let(:easting) { 308901 }
+    let(:northing) { 101053 }
+    let(:location) { described_class.new easting: easting, northing: northing }
+    
+    describe ".map_reference" do
+      it "should be calculated from easting and northing" do
+        expect(location.map_reference).to eq(map_reference)
+      end
+    end
+  end
 end
 

--- a/spec/os_map_ref/location_spec.rb
+++ b/spec/os_map_ref/location_spec.rb
@@ -3,10 +3,10 @@ require "spec_helper"
 describe OsMapRef::Location do
   
   let(:map_reference) { 'ST 58901 71053' }
-  let(:long_map_reference) { 'ST 58901 121053' }
-  let(:easting) { 358901 }
-  let(:northing) { 171053 }
-  let(:long_northing) { 1171053 }
+  let(:easting) { "358901" }
+  let(:northing) { "171053" }
+  let(:long_map_reference) { "HT 58901 71053" }
+  let(:long_northing) { "1171053" }
 
   describe ".for" do
     it "should accept a map reference" do
@@ -101,7 +101,7 @@ describe OsMapRef::Location do
     end
   end
   
-  context "when initiated with easting and northing" do
+  context "when initiated with easting and long northing" do
     let(:location) { described_class.new easting: easting, northing: long_northing }
     
     describe ".grid_northing" do
@@ -119,14 +119,102 @@ describe OsMapRef::Location do
   
   context "when eastings and northing second character a zero" do
     let(:map_reference) { 'ST 08901 01053' }
-    let(:easting) { 308901 }
-    let(:northing) { 101053 }
+    let(:easting) { "308901" }
+    let(:northing) { "101053" }
     let(:location) { described_class.new easting: easting, northing: northing }
     
     describe ".map_reference" do
       it "should be calculated from easting and northing" do
         expect(location.map_reference).to eq(map_reference)
       end
+    end
+  end
+  
+  context "when eastings and northing contain decimals" do
+    let(:map_reference) { 'ST 08901 01053' }
+    let(:easting) { "308901.4" }
+    let(:northing) { "101053.3" }
+    let(:location) { described_class.new easting: easting, northing: northing }
+    
+    describe ".map_reference" do
+      it "should be calculated from easting and northing" do
+        expect(location.map_reference).to eq(map_reference)
+      end
+    end
+  end
+  
+  context "when eastings and northing is one unit into grid from origin" do
+    let(:map_reference) { 'SV 00001 00001' }
+    let(:easting) { "000001" }
+    let(:northing) { "000001" }
+
+    context "and eastings and northings defined" do
+      let(:location) { described_class.new easting: easting, northing: northing }
+
+      describe ".map_reference" do
+        it "should be calculated from easting and northing" do
+          expect(location.map_reference).to eq(map_reference)
+        end
+      end
+    end
+    
+    context "and map reference is defined" do
+      let(:location) { described_class.new map_reference: map_reference }
+
+      describe ".easting" do
+        it "should be calculated from map_reference" do
+          expect(location.easting).to eq(easting)
+        end
+      end
+
+      describe ".northing" do
+        it "should be calculated from map_reference" do
+          expect(location.northing).to eq(northing)
+        end
+      end
+    end
+  end
+  
+  context "when northing is long" do
+    let(:map_reference) { long_map_reference }
+    let(:northing) { long_northing }
+
+    context "and eastings and northings defined" do
+      let(:location) { described_class.new easting: easting, northing: northing }
+
+      describe ".map_reference" do
+        it "should be calculated from easting and northing" do
+          expect(location.map_reference).to eq(map_reference)
+        end
+      end
+    end
+    
+    context "and map reference is defined" do
+      let(:location) { described_class.new map_reference: map_reference }
+
+      describe ".easting" do
+        it "should be calculated from map_reference" do
+          expect(location.easting).to eq(easting)
+        end
+      end
+
+      describe ".northing" do
+        it "should be calculated from map_reference" do
+          expect(location.northing).to eq(northing)
+        end
+      end
+    end
+  end
+  
+  describe ".remove_decimals" do
+    let(:location) { described_class.new map_reference: map_reference }
+    
+    it "should return the number if no decimals" do
+      expect(location.remove_decimals "308901").to eq("308901")
+    end
+    
+    it "should return the number with decimals removed" do
+      expect(location.remove_decimals "308901.4").to eq("308901")
     end
   end
 end


### PR DESCRIPTION
Allows use of OsMapRef.for with decimal eastings/northings e.g. 12345.6
Fixes bugs related to long northings. e.g. Grid refs starting with "H"
Fixes bugs related to easting/northing having a second digit as zero e.g. 10234
