### PR TITLE
Add version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # OsMapRef
 
 [![Build Status](https://travis-ci.org/EnvironmentAgency/os_map_ref.svg?branch=master)](https://travis-ci.org/EnvironmentAgency/os_map_ref)
+[![Gem Version](https://badge.fury.io/rb/os_map_ref.svg)](https://badge.fury.io/rb/os_map_ref)
 
 This gem allows you to gather U.K. Ordnance Survey Eastings, North, and Map
 References from a range of text inputs.


### PR DESCRIPTION
This change simply adds a version badge to the README. As https://badge.fury.io puts it

> Version Badge provides a consistent way for the Ruby community to learn about the RubyGem associated with a particular Github repository and other documentation pages. Once the Gem owner adds this badge to their README file, it will inform and link all visitors to the latest version of that Gem.
