### PR TITLE
Integrate project with codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,21 @@
+---
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - ruby
+  fixme:
+    enabled: true
+  rubocop:
+    enabled: true
+  brakeman:
+    enabled: false
+  rubymotion:
+    enabled: true
+ratings:
+  paths:
+  - "**.module"
+  - "**.rb"
+exclude_paths:
+- spec/

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,12 @@ before_install: gem install bundler -v 1.11.2
 branches:
   only:
     - master
+
+# This section was added as per https://docs.travis-ci.com/user/code-climate/
+# To protect our codeclimate stats rather than adding the Codeclimate API key for ea-area_lookup
+# in the open we used this guide https://docs.travis-ci.com/user/encryption-keys/ to encryt the
+# value. Essentially install travis gem, then run `travis encrypt <my_code_climate_api_key>`
+addons:
+  code_climate:
+    repo_token:
+      secure: "cUy8PwjoMp7aBx60f9aDxyrALeXjfkCljpD6O1hVxxYPnqabZ1FoDGkpxBHEblXF8PBxEGnezlGj5jILk+5DrYbm43uyylHuSgNE7Qry/4ceDnBLyMXjrg4f0FplLt7h8sflHbUJoPy7fwnk/9tUORZmOpi9gp05o583gqk/NiEeyGl2tm+nxrvmgAyxQPDNPOF1iwTrdjbdRm/bUf5kMhLzoXJJ09BLCSARbvQTgB5kklwQ7ggnB0/54oCEahHWfLQTAq2dwVU1usSJbIi6U2WNES8nttZEe7bUSAGTiOGrnez4fqJ96VLBjQQhtJfaDrC5HWzqlaMVyUZYAQd5qXIVMS4N4ddxeQcd9y5D5uYHKvJFnwxJXPl0plGQiq2wLc2UakgQhQaIFz34HbTi45VkYFDEYlaPiRJ3AfXp35pmeVJDdpcNqfr6B7Kjo+CNmLRa68ec9hwIQ8gxvhD1SwmJLL8hIeTomy/040+0T6jJq9dxj9gM9+MG0jzg4/HXpDghTFQGZhw3JPVhvT0lyHQGEjUsVhQCWjVtPpKuBX5JazqfSAY5m41wY0vfS30rvxBlkYuGeebmpltm8ezhAtLoIjLGsBGLphmoIS6fTNFhIPAYI5FJYMgp2+6ZoLgMFOecLfw8fLxgHbxfOR/YHReYkTuk3kISZ7IN0Y7pC+U="

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,6 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in os_map_ref.gemspec
 gemspec
+
+# Required to enable codeclimate's test coverage functionality
+gem "codeclimate-test-reporter", group: :test, require: nil

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # OsMapRef
 
 [![Build Status](https://travis-ci.org/EnvironmentAgency/os_map_ref.svg?branch=master)](https://travis-ci.org/EnvironmentAgency/os_map_ref)
+[![Code Climate](https://codeclimate.com/github/EnvironmentAgency/os_map_ref/badges/gpa.svg)](https://codeclimate.com/github/EnvironmentAgency/os_map_ref)
+[![Test Coverage](https://codeclimate.com/github/EnvironmentAgency/os_map_ref/badges/coverage.svg)](https://codeclimate.com/github/EnvironmentAgency/os_map_ref/coverage)
 [![Gem Version](https://badge.fury.io/rb/os_map_ref.svg)](https://badge.fury.io/rb/os_map_ref)
 
 This gem allows you to gather U.K. Ordnance Survey Eastings, North, and Map

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require "codeclimate-test-reporter"
+CodeClimate::TestReporter.start
 require_relative '../lib/os_map_ref'
 
 RSpec.configure do |config|


### PR DESCRIPTION
We believe that using metrics such as those provided by Codeclimate help us to ensure the quality of the code and artifacts we produce. This change integrates the repo with codeclimate by making the following changes
- Adding a .codeclimate.yml config file
- Adding the 'codeclimate-test-reporter' gem and configuring it to run in rspec
- Configuring Travis to send test coverage stats to codeclimate after builds
- Adding the codeclimate badges to the README
