### PR TITLE
Fix rubocop issue

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ Bundler::GemHelper.install_tasks
 # This is wrapped to prevent an error when rake is called in environments where
 # rspec may not be available, e.g. production. As such we don't need to handle
 # the error.
-# rubocop:disable Lint/HandleExceptions
+# rubocop:disable Lint/SuppressedException
 begin
   require "rspec/core/rake_task"
 
@@ -21,7 +21,7 @@ begin
 rescue LoadError
   # no rspec available
 end
-# rubocop:enable Lint/HandleExceptions
+# rubocop:enable Lint/SuppressedException
 
 require "github_changelog_generator/task"
 


### PR DESCRIPTION
The latest version of rubocop has changed the namespace for suppressing exceptions. This resolves the issue and prevents rubocop raising

```bash
Inspecting 12 files
.W.....os_map_ref.gemspec: Metrics/LineLength has the wrong namespace - should be Layout
os_map_ref.gemspec: Metrics/LineLength has the wrong namespace - should be Layout
.....
Offenses:
Rakefile:14:1: W: Lint/RedundantCopDisableDirective: Unnecessary disabling of Lint/HandleExceptions (unknown cop).
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Rakefile:21:1: W: Lint/SuppressedException: Do not suppress exceptions. (https://rubystyle.guide#dont-hide-exceptions)
rescue LoadError
^^^^^^^^^^^^^^^^
12 files inspected, 2 offenses detected
```