### PR TITLE
Use pry in bin/console

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -6,9 +6,5 @@ require "os_map_ref"
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
 
-# (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
-
-require "irb"
-IRB.start
+require "pry"
+Pry.start

--- a/os_map_ref.gemspec
+++ b/os_map_ref.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
   # ~/.bash_profile (or equivalent)
   # https://github.com/skywinder/github-changelog-generator#github-token
   s.add_development_dependency "github_changelog_generator"
+  s.add_development_dependency "pry-byebug"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", "~> 3.8"
   s.add_development_dependency "simplecov", "~> 0.17.1"


### PR DESCRIPTION
Sometimes it's useful to be able to load the gem and interact with the classes in order to test and debug the code.

A great way to do this is the `bin/console` file found in most gems.

When you load the console the default is to open [irb](https://github.com/ruby/irb) with your project loaded. However, our standard is to use [pry](https://github.com/pry/pry).

In fact, switching is so common that the code to use `pry` is automatically added when you create the gem. It's just commented out.

We bring in the gem [pry-byebug](https://github.com/deivid-rodriguez/pry-byebug.git), which in turn brings in the pry gem. So we have everything we need to switch to using our preferred REPL. Hence we make that change here.