### PR TITLE
Fix issue in travis with bundler args

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ git:
 
 before_install:
   - export TZ=UTC
-  - gem install -v 1.17.3 bundler --no-rdoc --no-ri
+  - gem install -v 1.17.3 bundler --no-document
 
 script:
   - bundle exec rubocop --format progress --format json --out rubocop-result.json


### PR DESCRIPTION
We recently started seeing Travis CI builds failing.

The main error is:

```bash
$ gem install -v 1.17.3 bundler --no-rdoc --no-ri
ERROR:  While executing gem ... (OptionParser::InvalidOption)
    invalid option: --no-rdoc
The command "gem install -v 1.17.3 bundler --no-rdoc --no-ri" failed and exited with 1 during .
```

Visible in https://travis-ci.com/github/DEFRA/os-map-ref/builds/171735066

We think the only difference in the builds is the version of the ruby binary Travis is pulling. But for now we are simply going to switch our args to move past the issue and get things building again.