### PR TITLE
Resolve redundant regex issue found by rubocop

### DIFF
--- a/lib/os_map_ref/input_processor.rb
+++ b/lib/os_map_ref/input_processor.rb
@@ -115,7 +115,7 @@ module OsMapRef
       eastings = /\d{3,6}/  # 3 to 6 digits
       northings = /\d{3,7}/ # 3 to 7 digits
       decimals = /\.\d+/    # decimal point and trailing digits
-      separator = /[\,\s]+/ # commas or spaces
+      separator = /[,\s]+/ # commas or spaces
       /(#{eastings}(#{decimals})?)#{separator}(#{northings}(#{decimals})?)/
     end
   end


### PR DESCRIPTION
Fix

```bash
lib/os_map_ref/input_processor.rb:118:21: C: Redundant escape inside regexp literal
      separator = /[\,\s]+/ # commas or spaces
                    ^^
12 files inspected, 1 offense detected
```