### PR TITLE
Switch from Travis CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on: push
+
+jobs:
+  build:
+    # You must use a Linux environment when using service containers or container jobs
+    runs-on: ubuntu-latest
+
+    steps:
+      # Downloads a copy of the code in your repository before running CI tests
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
+
+      # We don't have to specify the ruby version, or grab it from .ruby-verion. This action supports reading the
+      # version from .ruby-verion itself
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+      # Run linting first. No point running the tests if there is a linting issue
+      - name: Run lint check
+        run: |
+          bundle exec rubocop --format progress --format json --out rubocop-result.json
+
+      # This includes an extra run step. The sonarcloud analysis will be run in a docker container with the current
+      # folder mounted as `/github/workspace`. The problem is when the .resultset.json file is generated it will
+      # reference the code in the current folder. So to enable sonarcloud to matchup code coverage with the files we use
+      # sed to update the references in .resultset.json
+      # https://community.sonarsource.com/t/code-coverage-doesnt-work-with-github-action/16747/6
+      - name: Run unit tests
+        run: |
+          bundle exec rspec
+          sed -i 's/\/home\/runner\/work\/defra-ruby-alert\/defra-ruby-alert\//\/github\/workspace\//g' coverage/.resultset.json
+
+      - name: Analyze with SonarCloud
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is provided automatically by GitHub
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # This needs to be set in your repo; settings -> secrets

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # OsMapRef
 
-[![Build Status](https://travis-ci.com/DEFRA/os-map-ref.svg?branch=main)](https://travis-ci.com/DEFRA/os-map-ref)
+![Build Status](https://github.com/DEFRA/os-map-ref/workflows/CI/badge.svg?branch=main)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_os-map-ref&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=DEFRA_os-map-ref)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_os-map-ref&metric=coverage)](https://sonarcloud.io/dashboard?id=DEFRA_os-map-ref)
-[![security](https://hakiri.io/github/DEFRA/os-map-ref/main.svg)](https://hakiri.io/github/DEFRA/os-map-ref/main)
 [![Gem Version](https://badge.fury.io/rb/os_map_ref.svg)](https://badge.fury.io/rb/os_map_ref)
 [![Licence](https://img.shields.io/badge/Licence-OGLv3-blue.svg)](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3)
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,7 +8,7 @@ sonar.projectVersion=0.5.0
 
 # This will add the same links in the SonarCloud UI
 sonar.links.homepage=https://github.com/DEFRA/os-map-ref
-sonar.links.ci=https://travis-ci.com/DEFRA/os-map-ref
+sonar.links.ci=https://github.com/DEFRA/os-map-ref/actions
 sonar.links.scm=https://github.com/DEFRA/os-map-ref
 sonar.links.issue=https://github.com/DEFRA/ruby-services-team/issues
 


### PR DESCRIPTION
We decided some time ago to switch our repos from using Travis-CI to GitHub Actions. However, this repo seems to have been overlooked.

This change switches the repo from Travis-CI to GitHub Actions.